### PR TITLE
Next

### DIFF
--- a/BelligerentBlocks/.cproject
+++ b/BelligerentBlocks/.cproject
@@ -33,9 +33,7 @@
 							</tool>
 							<tool id="com.qnx.qcc.tool.assembler.1877792982" name="QCC Assembler" superClass="com.qnx.qcc.tool.assembler">
 								<option id="com.qnx.qcc.option.assembler.debug.1420078834" name="Debug (-g)" superClass="com.qnx.qcc.option.assembler.debug" value="true" valueType="boolean"/>
-								<option id="com.qnx.qcc.option.assembler.includePath.1487618317" name="Include Directories (-I)" superClass="com.qnx.qcc.option.assembler.includePath" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d}&quot;"/>
-								</option>
+								<option id="com.qnx.qcc.option.assembler.includePath.1487618317" name="Include Directories (-I)" superClass="com.qnx.qcc.option.assembler.includePath" valueType="includePath"/>
 								<inputType id="com.qnx.qcc.inputType.assembler.95727227" superClass="com.qnx.qcc.inputType.assembler"/>
 							</tool>
 							<tool id="com.qnx.qcc.tool.linker.1939018054" name="QCC Linker" superClass="com.qnx.qcc.tool.linker">
@@ -43,9 +41,11 @@
 								<option id="com.qnx.qcc.option.linker.langcpp.2078359075" name="C++ (-lang-c++)" superClass="com.qnx.qcc.option.linker.langcpp" value="true" valueType="boolean"/>
 								<option id="com.qnx.qcc.option.linker.libraries.398104278" name="Libraries (-l)" superClass="com.qnx.qcc.option.linker.libraries" valueType="libs">
 									<listOptionValue builtIn="false" value="box2d"/>
+									<listOptionValue builtIn="false" value="scoreloopcore"/>
 									<listOptionValue builtIn="false" value="bps"/>
 									<listOptionValue builtIn="false" value="sqlite3"/>
 									<listOptionValue builtIn="false" value="asound"/>
+									<listOptionValue builtIn="false" value="screen"/>
 									<listOptionValue builtIn="false" value="OpenAL"/>
 									<listOptionValue builtIn="false" value="alut"/>
 									<listOptionValue builtIn="false" value="curl"/>
@@ -58,13 +58,10 @@
 									<listOptionValue builtIn="false" value="GLESv1_CM"/>
 								</option>
 								<option id="com.qnx.qcc.option.linker.objectFiles.169776357" name="Additional Object Files" superClass="com.qnx.qcc.option.linker.objectFiles"/>
-								<option id="com.qnx.qcc.option.linker.qccoptions.1492265882" name="QCC Options" superClass="com.qnx.qcc.option.linker.qccoptions" valueType="stringList">
-									<listOptionValue builtIn="false" value="-Bstatic -lscoreloopcore -Bdynamic"/>
-								</option>
+								<option id="com.qnx.qcc.option.linker.qccoptions.1492265882" name="QCC Options" superClass="com.qnx.qcc.option.linker.qccoptions" valueType="stringList"/>
 								<option id="com.qnx.qcc.option.linker.defLibraryPaths.1516517177" superClass="com.qnx.qcc.option.linker.defLibraryPaths"/>
 								<option id="com.qnx.qcc.option.linker.libraryPaths.519401205" name="Library Paths (-L)" superClass="com.qnx.qcc.option.linker.libraryPaths" valueType="libPaths">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d/Device-Release}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d/arm/a-le-v7}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d/Device-Debug}&quot;"/>
 								</option>
 								<inputType id="com.qnx.qcc.inputType.linker.1617475221" superClass="com.qnx.qcc.inputType.linker">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
@@ -84,7 +81,7 @@
 				<externalSettings containerId="box2d;" factoryId="org.eclipse.cdt.core.cfg.export.settings.sipplier">
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/box2d"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/box2d/Device-Release"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/box2d/Simulator"/>
 						<entry flags="RESOLVED" kind="libraryFile" name="box2d"/>
 					</externalSetting>
 				</externalSettings>
@@ -111,10 +108,9 @@
 								<option id="com.qnx.qcc.option.compiler.optlevel.902391483" name="Optimization Level" superClass="com.qnx.qcc.option.compiler.optlevel" value="com.qnx.qcc.option.compiler.optlevel.2" valueType="enumerated"/>
 								<option id="com.qnx.qcc.option.compiler.includePath.1763123111" name="Include Directories (-I)" superClass="com.qnx.qcc.option.compiler.includePath" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${QNX_TARGET}/../target-override/usr/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${QNX_TARGET}/usr/include/freetype2&quot;"/>
 								</option>
-								<option id="com.qnx.qcc.option.compiler.qccoptions.1186023828" superClass="com.qnx.qcc.option.compiler.qccoptions" valueType="stringList">
+								<option id="com.qnx.qcc.option.compiler.qccoptions.1186023828" name="QCC Options" superClass="com.qnx.qcc.option.compiler.qccoptions" valueType="stringList">
 									<listOptionValue builtIn="false" value="-DUSING_GL11"/>
 								</option>
 								<inputType id="com.qnx.qcc.inputType.compiler.1394666629" superClass="com.qnx.qcc.inputType.compiler"/>
@@ -126,6 +122,8 @@
 								<option id="com.qnx.qcc.option.linker.langcpp.893553657" name="C++ (-lang-c++)" superClass="com.qnx.qcc.option.linker.langcpp" value="true" valueType="boolean"/>
 								<option id="com.qnx.qcc.option.linker.libraries.1244522227" name="Libraries (-l)" superClass="com.qnx.qcc.option.linker.libraries" valueType="libs">
 									<listOptionValue builtIn="false" value="bps"/>
+									<listOptionValue builtIn="false" value="screen"/>
+									<listOptionValue builtIn="false" value="scoreloopcore"/>
 									<listOptionValue builtIn="false" value="sqlite3"/>
 									<listOptionValue builtIn="false" value="asound"/>
 									<listOptionValue builtIn="false" value="OpenAL"/>
@@ -141,12 +139,9 @@
 									<listOptionValue builtIn="false" value="GLESv1_CM"/>
 								</option>
 								<option id="com.qnx.qcc.option.linker.libraryPaths.1198487044" name="Library Paths (-L)" superClass="com.qnx.qcc.option.linker.libraryPaths" valueType="libPaths">
-									<listOptionValue builtIn="false" value="&quot;${QNX_TARGET}/../target-override/armle-v7/usr/lib&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d/arm/a-le-v7}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d/Device-Release}&quot;"/>
 								</option>
-								<option id="com.qnx.qcc.option.linker.qccoptions.338322515" name="QCC Options" superClass="com.qnx.qcc.option.linker.qccoptions" valueType="stringList">
-									<listOptionValue builtIn="false" value="-Bstatic -lscoreloopcore -Bdynamic"/>
-								</option>
+								<option id="com.qnx.qcc.option.linker.qccoptions.338322515" name="QCC Options" superClass="com.qnx.qcc.option.linker.qccoptions" valueType="stringList"/>
 								<inputType id="com.qnx.qcc.inputType.linker.1849835206" superClass="com.qnx.qcc.inputType.linker">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
@@ -183,10 +178,9 @@
 								<option id="com.qnx.qcc.option.compile.debug.1545241985" name="Debug (-g)" superClass="com.qnx.qcc.option.compile.debug" value="true" valueType="boolean"/>
 								<option id="com.qnx.qcc.option.compiler.includePath.1763123111" name="Include Directories (-I)" superClass="com.qnx.qcc.option.compiler.includePath" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${QNX_TARGET}/../target-override/usr/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${QNX_TARGET}/usr/include/freetype2&quot;"/>
 								</option>
-								<option id="com.qnx.qcc.option.compiler.qccoptions.1718995789" superClass="com.qnx.qcc.option.compiler.qccoptions" valueType="stringList">
+								<option id="com.qnx.qcc.option.compiler.qccoptions.1718995789" name="QCC Options" superClass="com.qnx.qcc.option.compiler.qccoptions" valueType="stringList">
 									<listOptionValue builtIn="false" value="-DUSING_GL11"/>
 								</option>
 								<inputType id="com.qnx.qcc.inputType.compiler.153315798" superClass="com.qnx.qcc.inputType.compiler"/>
@@ -200,6 +194,8 @@
 								<option id="com.qnx.qcc.option.linker.langcpp.1894273893" name="C++ (-lang-c++)" superClass="com.qnx.qcc.option.linker.langcpp" value="true" valueType="boolean"/>
 								<option id="com.qnx.qcc.option.linker.libraries.2006706880" name="Libraries (-l)" superClass="com.qnx.qcc.option.linker.libraries" valueType="libs">
 									<listOptionValue builtIn="false" value="bps"/>
+									<listOptionValue builtIn="false" value="scoreloopcore"/>
+									<listOptionValue builtIn="false" value="screen"/>
 									<listOptionValue builtIn="false" value="sqlite3"/>
 									<listOptionValue builtIn="false" value="asound"/>
 									<listOptionValue builtIn="false" value="OpenAL"/>
@@ -215,12 +211,9 @@
 									<listOptionValue builtIn="false" value="GLESv1_CM"/>
 								</option>
 								<option id="com.qnx.qcc.option.linker.libraryPaths.424108766" name="Library Paths (-L)" superClass="com.qnx.qcc.option.linker.libraryPaths" valueType="libPaths">
-									<listOptionValue builtIn="false" value="&quot;${QNX_TARGET}/../target-override/x86/usr/lib&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d/x86/a}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/box2d/Simulator}&quot;"/>
 								</option>
-								<option id="com.qnx.qcc.option.linker.qccoptions.1093499477" name="QCC Options" superClass="com.qnx.qcc.option.linker.qccoptions" valueType="stringList">
-									<listOptionValue builtIn="false" value="-Bstatic -lscoreloopcore -Bdynamic"/>
-								</option>
+								<option id="com.qnx.qcc.option.linker.qccoptions.1093499477" name="QCC Options" superClass="com.qnx.qcc.option.linker.qccoptions" valueType="stringList"/>
 								<inputType id="com.qnx.qcc.inputType.linker.8798000" superClass="com.qnx.qcc.inputType.linker">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>

--- a/BelligerentBlocks/bar-descriptor.xml
+++ b/BelligerentBlocks/bar-descriptor.xml
@@ -54,7 +54,6 @@
    <action system="true">run_native</action>
 
    <!-- Permission needed for Scoreloop -->
-   <action>read_device_identifying_information</action>
    <action>play_audio</action>
 
    <env var="LD_LIBRARY_PATH" value="app/native/lib"/>

--- a/BelligerentBlocks/src/GameLogic.cpp
+++ b/BelligerentBlocks/src/GameLogic.cpp
@@ -357,13 +357,13 @@ void GameLogic::renderGame() {
 
     //Display score
     char buf[100];
-    sprintf(buf, "%i\0", m_score);
+    sprintf(buf, "%i", m_score);
 
     bbutil_render_text(m_scoreFont, buf, m_scorePosX, m_scorePosY, 0.75f, 0.75f, 0.75f, 1.0f);
 
     //Display timer if it is available
     if (m_showClock) {
-        sprintf(buf, "Time left %i\0", m_time - m_scoreTime - 1l);
+        sprintf(buf, "Time left %i", m_time - m_scoreTime - 1);
         bbutil_render_text(m_font, buf, m_timerPosX, m_timerPosY, 0.75f, 0.75f, 0.75f, 1.0f);
     }
     m_platform.finishRender();
@@ -406,7 +406,7 @@ void GameLogic::renderLeadBoard() {
             bbutil_render_text(m_leaderboardFont, buf, m_leaderBoard.PosX() - m_leaderBoard.Width() / 2 + LEADERBOARD_LINE_OFFSET_X, posY,
                                1.0f, 1.0f, 1.0f, 1.0f);
 
-            sprintf(buf, "%i", m_leaderboard[i].score());
+            sprintf(buf, "%li", m_leaderboard[i].score());
             bbutil_measure_text(m_leaderboardFont, buf, &sizeX, &sizeY);
 
             bbutil_render_text(m_leaderboardFont, buf, m_leaderBoard.PosX() + m_leaderBoard.Width() / 2 - sizeX - LEADERBOARD_LINE_OFFSET_X, posY,


### PR DESCRIPTION
Remove the "device identifying information" permissions since scoreloop no
longer needs it.  Link against the scoreloopcore DSO rather than the
static archive.  Ensure all build targets are configured correctly.

Applied a few minor fixes to get rid of the warnings.
