### PR TITLE
Removal of reference to shadow.png

### DIFF
--- a/GoodCitizen/manifest.properties
+++ b/GoodCitizen/manifest.properties
@@ -51,7 +51,7 @@ sources: bbutil.h bbutil.c main.c
 
 flags.compiler: -DUSING_GL11
 
-resources: radio_btn_selected.png radio_btn_unselected.png shadow.png LICENSE NOTICE
+resources: radio_btn_selected.png radio_btn_unselected.png LICENSE NOTICE
 
 readmes: readme.txt
 


### PR DESCRIPTION
shadow.png is no longer needed.
