### PR TITLE
Fix blocks falling at strange angles

### DIFF
--- a/FallingBlocks/main.c
+++ b/FallingBlocks/main.c
@@ -411,7 +411,7 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    // Pitch/Roll data doesn't change for the simulator
+    // Gravity data doesn't change for the simulator
     deviceinfo_details_t *details;
     bool is_simulator = false;
     if (BPS_SUCCESS == deviceinfo_get_details(&details)) {


### PR DESCRIPTION
Gravity data doesn't change for the simulator, so hardcode it so that blocks fall straight down on the simulator.  Remove initial orientation query, it is no longer being used.
